### PR TITLE
Ruby 1.9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+
 require 'rubygems'
 require 'minitest/unit'
 require 'fileutils'


### PR DESCRIPTION
Added load path modification to the Rakefile, as it won't install under Ruby 1.9 without it.
